### PR TITLE
Removed the import of bits/stdc++

### DIFF
--- a/src/automata/state.cpp
+++ b/src/automata/state.cpp
@@ -1,4 +1,3 @@
-#include <bits/stdc++.h>
 #include "state.h"
 
 namespace yunolex {


### PR DESCRIPTION
The header is compiler-bound, so clang or macos wouldn't be able to compile the project. The header itself, if you look at the GNU GCC source -> https://gcc.gnu.org/onlinedocs/gcc-4.8.0/libstdc++/api/a01541_source.html

It imports every header under the Sun, so even at the header level, makes unnecessary imports. Because it imports precompiled headers, it can theoretically speedup compilation (if used right, not intimate with the subtleties myself), but other compilers can't use it.

Removing it compiles the project on any platform now. Your set operations and other calls to C++ stdlib are already handled in other files.

Theoretically, you could maintain a local copy of `bits/stdc++` to make it cross-platform -> https://gist.github.com/frankchen0130/9ac562b55fa7e03689bca30d0e52b0e5